### PR TITLE
@mixin instead of @element?

### DIFF
--- a/core-focusable.js
+++ b/core-focusable.js
@@ -5,7 +5,7 @@
  * Elements using this mixin will receive attributes reflecting the focus, pressed
  * and disabled states.
  *
- * @element Polymer.CoreFocusable
+ * @mixin Polymer.CoreFocusable
  * @status unstable
  */
 


### PR DESCRIPTION
This isn't actually an element, so it should have a different directive. I have suggested just @mixin here, but that might be somewhat confusing with @mixins on the elements that include this mixin.
